### PR TITLE
Feat/#6/무당이 기능 구현

### DIFF
--- a/Movement-Service/build.gradle
+++ b/Movement-Service/build.gradle
@@ -34,6 +34,13 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Spring Data Jpa
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
 }
 
 dependencyManagement {

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/MovementServiceApplication.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/MovementServiceApplication.java
@@ -3,9 +3,11 @@ package com.gachonproject.movementservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableJpaAuditing
 public class MovementServiceApplication {
 
     public static void main(String[] args) {

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/MudangController.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/MudangController.java
@@ -40,4 +40,12 @@ public class MudangController {
         return ApiResponse.response(HttpStatus.OK, MUDANG_UPDATE.getMessage());
     }
 
+    @DeleteMapping("/admin/mudang/{mudangId}")
+    public ApiResponse<Void> deleteMudangTime(@PathVariable Long mudangId) {
+
+        mudangUseCase.deleteMudang(mudangId);
+
+        return ApiResponse.response(HttpStatus.OK, MUDANG_DELETE.getMessage());
+    }
+
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/MudangController.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/MudangController.java
@@ -26,6 +26,12 @@ public class MudangController {
         return ApiResponse.response(HttpStatus.OK, MUDANG_CREATE.getMessage());
     }
 
+    @GetMapping("/member/mudang")
+    public ApiResponse<String> getMudangTime() {
 
+        String response = mudangUseCase.getMudangTime();
+
+        return ApiResponse.response(HttpStatus.OK, MUDANG_SINGLE_TIME.getMessage(), response);
+    }
 
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/MudangController.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/MudangController.java
@@ -34,4 +34,10 @@ public class MudangController {
         return ApiResponse.response(HttpStatus.OK, MUDANG_SINGLE_TIME.getMessage(), response);
     }
 
+    @PatchMapping("/admin/mudang")
+    public ApiResponse<Void> updateMudangTime(@RequestBody MudangUpdateDto dto) {
+        mudangUseCase.updateMudang(dto);
+        return ApiResponse.response(HttpStatus.OK, MUDANG_UPDATE.getMessage());
+    }
+
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/MudangController.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/MudangController.java
@@ -1,0 +1,31 @@
+package com.gachonproject.movementservice.domain.mudang.controller;
+
+import com.gachonproject.movementservice.domain.mudang.dto.request.MudangSaveDto;
+import com.gachonproject.movementservice.domain.mudang.dto.request.MudangUpdateDto;
+import com.gachonproject.movementservice.domain.mudang.service.MudangSaveService;
+import com.gachonproject.movementservice.domain.mudang.usecase.MudangUseCase;
+import com.gachonproject.movementservice.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import static com.gachonproject.movementservice.domain.mudang.controller.enums.SuccessMessage.*;
+
+@RestController
+@RequiredArgsConstructor
+public class MudangController {
+
+    private final MudangUseCase mudangUseCase;
+
+
+    @PostMapping("/admin/mudang")
+    public ApiResponse<Void> saveMudangTime(@RequestBody MudangSaveDto dto) {
+
+        mudangUseCase.createMudang(dto);
+
+        return ApiResponse.response(HttpStatus.OK, MUDANG_CREATE.getMessage());
+    }
+
+
+
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/MudangController.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/MudangController.java
@@ -2,12 +2,15 @@ package com.gachonproject.movementservice.domain.mudang.controller;
 
 import com.gachonproject.movementservice.domain.mudang.dto.request.MudangSaveDto;
 import com.gachonproject.movementservice.domain.mudang.dto.request.MudangUpdateDto;
+import com.gachonproject.movementservice.domain.mudang.dto.response.MudangDetailDto;
 import com.gachonproject.movementservice.domain.mudang.service.MudangSaveService;
 import com.gachonproject.movementservice.domain.mudang.usecase.MudangUseCase;
 import com.gachonproject.movementservice.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.gachonproject.movementservice.domain.mudang.controller.enums.SuccessMessage.*;
 
@@ -32,6 +35,17 @@ public class MudangController {
         String response = mudangUseCase.getMudangTime();
 
         return ApiResponse.response(HttpStatus.OK, MUDANG_SINGLE_TIME.getMessage(), response);
+    }
+
+    @GetMapping("/admin/mudang")
+    public ApiResponse<List<MudangDetailDto>> getMudangTimeList(
+            @RequestParam(defaultValue = "0", required = false) int pageNum,
+            @RequestParam(defaultValue = "10", required = false) int pageSize
+    ) {
+
+        List<MudangDetailDto> response = mudangUseCase.getMudangTimeList(pageNum, pageSize);
+
+        return ApiResponse.response(HttpStatus.OK, MUDANG_TIME_LIST.getMessage(), response);
     }
 
     @PatchMapping("/admin/mudang")

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/enums/SuccessMessage.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/enums/SuccessMessage.java
@@ -1,0 +1,16 @@
+package com.gachonproject.movementservice.domain.mudang.controller.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessMessage {
+
+    MUDANG_DELETE("무당이 시간표를 삭제했습니다."),
+    MUDANG_UPDATE("무당이 시간표를 변경했습니다."),
+    MUDANG_SINGLE_TIME("무당이 시간표를 반환합니다."),
+    MUDANG_CREATE("무당이 시간표를 성공적으로 생성했습니다.");
+
+    private final String message;
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/enums/SuccessMessage.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/controller/enums/SuccessMessage.java
@@ -10,6 +10,7 @@ public enum SuccessMessage {
     MUDANG_DELETE("무당이 시간표를 삭제했습니다."),
     MUDANG_UPDATE("무당이 시간표를 변경했습니다."),
     MUDANG_SINGLE_TIME("무당이 시간표를 반환합니다."),
+    MUDANG_TIME_LIST("무당이 시간표 목록을 반환합니다."),
     MUDANG_CREATE("무당이 시간표를 성공적으로 생성했습니다.");
 
     private final String message;

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/dto/request/MudangSaveDto.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/dto/request/MudangSaveDto.java
@@ -1,0 +1,6 @@
+package com.gachonproject.movementservice.domain.mudang.dto.request;
+
+public record MudangSaveDto(
+        String timeslot
+) {
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/dto/request/MudangUpdateDto.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/dto/request/MudangUpdateDto.java
@@ -1,0 +1,7 @@
+package com.gachonproject.movementservice.domain.mudang.dto.request;
+
+public record MudangUpdateDto(
+        Long mudangId,
+        String timeslot
+) {
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/dto/response/MudangDetailDto.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/dto/response/MudangDetailDto.java
@@ -1,0 +1,17 @@
+package com.gachonproject.movementservice.domain.mudang.dto.response;
+
+import com.gachonproject.movementservice.domain.mudang.entity.Mudang;
+import lombok.Builder;
+
+@Builder
+public record MudangDetailDto(
+        Long mudangId,
+        String timeslot
+) {
+    public static MudangDetailDto from(Mudang mudang) {
+        return MudangDetailDto.builder()
+                .mudangId(mudang.getId())
+                .timeslot(mudang.getTimeslot())
+                .build();
+    }
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/entity/Mudang.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/entity/Mudang.java
@@ -24,4 +24,8 @@ public class Mudang extends BaseEntity {
                 .build();
     }
 
+    public void updateTimeslot(String timeslot) {
+        this.timeslot = timeslot;
+    }
+
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/entity/Mudang.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/entity/Mudang.java
@@ -1,0 +1,27 @@
+package com.gachonproject.movementservice.domain.mudang.entity;
+
+import com.gachonproject.movementservice.domain.mudang.dto.request.MudangSaveDto;
+import com.gachonproject.movementservice.global.common.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@SuperBuilder
+@Table(name = "Mudang")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Mudang extends BaseEntity {
+
+    private String timeslot;
+
+    public static Mudang from(MudangSaveDto dto) {
+        return Mudang.builder()
+                .timeslot(dto.timeslot())
+                .build();
+    }
+
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/exception/DuplicatedMudangException.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/exception/DuplicatedMudangException.java
@@ -1,0 +1,12 @@
+package com.gachonproject.movementservice.domain.mudang.exception;
+
+import com.gachonproject.movementservice.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import static com.gachonproject.movementservice.domain.mudang.exception.enums.ErrorMessage.DUPLICATED_MUDANG_EXCEPTION;
+
+public class DuplicatedMudangException extends BaseException {
+    public DuplicatedMudangException() {
+        super(HttpStatus.BAD_REQUEST, DUPLICATED_MUDANG_EXCEPTION.getMessage());
+    }
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/exception/LargeBusRunException.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/exception/LargeBusRunException.java
@@ -1,0 +1,12 @@
+package com.gachonproject.movementservice.domain.mudang.exception;
+
+import com.gachonproject.movementservice.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import static com.gachonproject.movementservice.domain.mudang.exception.enums.ErrorMessage.LARGE_BUS_RUN_EXCEPTION;
+
+public class LargeBusRunException extends BaseException {
+    public LargeBusRunException() {
+        super(HttpStatus.BAD_REQUEST, LARGE_BUS_RUN_EXCEPTION.getMessage());
+    }
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/exception/MudangNotFoundException.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/exception/MudangNotFoundException.java
@@ -1,0 +1,12 @@
+package com.gachonproject.movementservice.domain.mudang.exception;
+
+import com.gachonproject.movementservice.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import static com.gachonproject.movementservice.domain.mudang.exception.enums.ErrorMessage.MUDANG_NOT_FOUND_EXCEPTION;
+
+public class MudangNotFoundException extends BaseException {
+    public MudangNotFoundException() {
+        super(HttpStatus.BAD_REQUEST, MUDANG_NOT_FOUND_EXCEPTION.getMessage());
+    }
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/exception/MudangTooLateException.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/exception/MudangTooLateException.java
@@ -1,0 +1,12 @@
+package com.gachonproject.movementservice.domain.mudang.exception;
+
+import com.gachonproject.movementservice.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import static com.gachonproject.movementservice.domain.mudang.exception.enums.ErrorMessage.TOO_LATE_EXCEPTION;
+
+public class MudangTooLateException extends BaseException {
+    public MudangTooLateException() {
+        super(HttpStatus.BAD_REQUEST, TOO_LATE_EXCEPTION.getMessage());
+    }
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/exception/enums/ErrorMessage.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/exception/enums/ErrorMessage.java
@@ -1,0 +1,17 @@
+package com.gachonproject.movementservice.domain.mudang.exception.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    MUDANG_NOT_FOUND_EXCEPTION("해당 무당이 시간표를 찾을 수 없습니다."),
+    DUPLICATED_MUDANG_EXCEPTION("중복되는 무당이 시간표입니다."),
+    LARGE_BUS_RUN_EXCEPTION("현재 대형버스 운행중입니다."),
+    TOO_LATE_EXCEPTION("너무 늦은 시간이라 무당이가 운행하지 않습니다");
+
+
+    private final String message;
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/repository/MudangRepository.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/repository/MudangRepository.java
@@ -1,0 +1,9 @@
+package com.gachonproject.movementservice.domain.mudang.repository;
+
+import com.gachonproject.movementservice.domain.mudang.entity.Mudang;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MudangRepository extends JpaRepository<Mudang, Long> {
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/repository/MudangRepository.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/repository/MudangRepository.java
@@ -6,4 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MudangRepository extends JpaRepository<Mudang, Long> {
+
+    Optional<Mudang> findMudangByTimeslot(String timeslot);
+
+    Optional<Mudang> findFirstByTimeslotGreaterThanOrderByTimeslotAsc(String timeslot);
+
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/repository/MudangRepository.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/repository/MudangRepository.java
@@ -1,8 +1,10 @@
 package com.gachonproject.movementservice.domain.mudang.repository;
 
 import com.gachonproject.movementservice.domain.mudang.entity.Mudang;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MudangRepository extends JpaRepository<Mudang, Long> {
@@ -10,5 +12,7 @@ public interface MudangRepository extends JpaRepository<Mudang, Long> {
     Optional<Mudang> findMudangByTimeslot(String timeslot);
 
     Optional<Mudang> findFirstByTimeslotGreaterThanOrderByTimeslotAsc(String timeslot);
+
+    List<Mudang> findMudangByOrderByTimeslotAsc(Pageable pageable);
 
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/service/MudangDeleteService.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/service/MudangDeleteService.java
@@ -1,0 +1,19 @@
+package com.gachonproject.movementservice.domain.mudang.service;
+
+import com.gachonproject.movementservice.domain.mudang.entity.Mudang;
+import com.gachonproject.movementservice.domain.mudang.repository.MudangRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MudangDeleteService {
+
+    private final MudangRepository mudangRepository;
+
+    @Transactional
+    public void deleteMudang(Mudang mudang) {
+        mudangRepository.delete(mudang);
+    }
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/service/MudangGetService.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/service/MudangGetService.java
@@ -6,7 +6,10 @@ import com.gachonproject.movementservice.domain.mudang.exception.MudangNotFoundE
 import com.gachonproject.movementservice.domain.mudang.exception.MudangTooLateException;
 import com.gachonproject.movementservice.domain.mudang.repository.MudangRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,9 +18,12 @@ public class MudangGetService {
     private final MudangRepository mudangRepository;
 
     public Mudang getMudang(String timeslot) {
-
         return mudangRepository.findFirstByTimeslotGreaterThanOrderByTimeslotAsc(timeslot)
                 .orElseThrow(MudangTooLateException::new);
+    }
+
+    public List<Mudang> getMudangTimeList(Pageable pageable) {
+        return mudangRepository.findMudangByOrderByTimeslotAsc(pageable);
     }
 
     public Mudang getMudangByMudangId(Long id) {

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/service/MudangGetService.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/service/MudangGetService.java
@@ -1,0 +1,33 @@
+package com.gachonproject.movementservice.domain.mudang.service;
+
+import com.gachonproject.movementservice.domain.mudang.entity.Mudang;
+import com.gachonproject.movementservice.domain.mudang.exception.DuplicatedMudangException;
+import com.gachonproject.movementservice.domain.mudang.exception.MudangNotFoundException;
+import com.gachonproject.movementservice.domain.mudang.exception.MudangTooLateException;
+import com.gachonproject.movementservice.domain.mudang.repository.MudangRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MudangGetService {
+
+    private final MudangRepository mudangRepository;
+
+    public Mudang getMudang(String timeslot) {
+
+        return mudangRepository.findFirstByTimeslotGreaterThanOrderByTimeslotAsc(timeslot)
+                .orElseThrow(MudangTooLateException::new);
+    }
+
+    public Mudang getMudangByMudangId(Long id) {
+        return mudangRepository.findById(id)
+                .orElseThrow(MudangNotFoundException::new);
+    }
+
+    public void checkValidTime(String timeslot) {
+        mudangRepository.findMudangByTimeslot(timeslot).ifPresent(mudang -> {
+            throw new DuplicatedMudangException();
+        });
+    }
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/service/MudangSaveService.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/service/MudangSaveService.java
@@ -1,0 +1,18 @@
+package com.gachonproject.movementservice.domain.mudang.service;
+
+import com.gachonproject.movementservice.domain.mudang.entity.Mudang;
+import com.gachonproject.movementservice.domain.mudang.repository.MudangRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MudangSaveService {
+
+    private final MudangRepository mudangRepository;
+
+    public void saveMudang(Mudang mudang) {
+        mudangRepository.save(mudang);
+    }
+
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/service/MudangUpdateService.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/service/MudangUpdateService.java
@@ -1,0 +1,21 @@
+package com.gachonproject.movementservice.domain.mudang.service;
+
+import com.gachonproject.movementservice.domain.mudang.dto.request.MudangUpdateDto;
+import com.gachonproject.movementservice.domain.mudang.entity.Mudang;
+import com.gachonproject.movementservice.domain.mudang.repository.MudangRepository;
+import jakarta.persistence.Table;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MudangUpdateService {
+
+    private final MudangRepository mudangRepository;
+
+    @Transactional
+    public void updateMudang(Mudang mudang, String timeslot) {
+        mudang.updateTimeslot(timeslot);
+    }
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/usecase/MudangUseCase.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/usecase/MudangUseCase.java
@@ -2,6 +2,7 @@ package com.gachonproject.movementservice.domain.mudang.usecase;
 
 import com.gachonproject.movementservice.domain.mudang.dto.request.MudangSaveDto;
 import com.gachonproject.movementservice.domain.mudang.dto.request.MudangUpdateDto;
+import com.gachonproject.movementservice.domain.mudang.dto.response.MudangDetailDto;
 import com.gachonproject.movementservice.domain.mudang.entity.Mudang;
 import com.gachonproject.movementservice.domain.mudang.exception.LargeBusRunException;
 import com.gachonproject.movementservice.domain.mudang.service.MudangDeleteService;
@@ -11,11 +12,13 @@ import com.gachonproject.movementservice.domain.mudang.service.MudangUpdateServi
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -46,6 +49,16 @@ public class MudangUseCase {
 
         long abs = getAbsTime(minusFiveMinute, mudang);
         return String.format(RESPONSE_FORMAT, mudang.getTimeslot(), abs);
+    }
+
+    public List<MudangDetailDto> getMudangTimeList(int pageNum, int pageSize) {
+
+        PageRequest pageRequest = PageRequest.of(pageNum, pageSize);
+
+        return mudangGetService.getMudangTimeList(pageRequest)
+                .stream()
+                .map(MudangDetailDto::from)
+                .toList();
     }
 
     @Transactional

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/usecase/MudangUseCase.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/usecase/MudangUseCase.java
@@ -37,6 +37,45 @@ public class MudangUseCase {
         mudangSaveService.saveMudang(Mudang.from(dto));
     }
 
+    public String getMudangTime() {
+        LocalTime now = LocalTime.now();
+        checkIsLunchTime(now);
 
+        String minusFiveMinute = getTimeToMinusRequestTime(now);
+        Mudang mudang = mudangGetService.getMudang(minusFiveMinute);
+
+        long abs = getAbsTime(minusFiveMinute, mudang);
+        return String.format(RESPONSE_FORMAT, mudang.getTimeslot(), abs);
+    }
+
+
+
+    /*
+    * refactor
+    * */
+
+    private static void checkIsLunchTime(LocalTime now) {
+        LocalTime start = LocalTime.of(11, 50);
+        LocalTime end = LocalTime.of(12, 50);
+
+        if (!now.isBefore(start) && !now.isAfter(end)) {
+            throw new LargeBusRunException();
+        }
+    }
+
+    private long getAbsTime(String minusFiveMinute, Mudang mudang) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(TIME_FORMAT);
+        LocalTime t1 = LocalTime.parse(minusFiveMinute, formatter);
+        LocalTime t2 = LocalTime.parse(mudang.getTimeslot(), formatter);
+
+        return Math.abs(Duration.between(t1, t2).toMinutes());
+    }
+
+    private String getTimeToMinusRequestTime(LocalTime now) {
+        LocalTime requestTime = now.minusMinutes(5);
+
+        String minusFiveMinute = requestTime.format(DateTimeFormatter.ofPattern(TIME_FORMAT));
+        return minusFiveMinute;
+    }
 
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/usecase/MudangUseCase.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/usecase/MudangUseCase.java
@@ -48,6 +48,14 @@ public class MudangUseCase {
         return String.format(RESPONSE_FORMAT, mudang.getTimeslot(), abs);
     }
 
+    @Transactional
+    public void updateMudang(MudangUpdateDto dto) {
+        mudangGetService.checkValidTime(dto.timeslot());
+
+        Mudang findMudang = mudangGetService.getMudangByMudangId(dto.mudangId());
+        mudangUpdateService.updateMudang(findMudang, dto.timeslot());
+    }
+
 
 
     /*

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/usecase/MudangUseCase.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/usecase/MudangUseCase.java
@@ -1,0 +1,42 @@
+package com.gachonproject.movementservice.domain.mudang.usecase;
+
+import com.gachonproject.movementservice.domain.mudang.dto.request.MudangSaveDto;
+import com.gachonproject.movementservice.domain.mudang.dto.request.MudangUpdateDto;
+import com.gachonproject.movementservice.domain.mudang.entity.Mudang;
+import com.gachonproject.movementservice.domain.mudang.exception.LargeBusRunException;
+import com.gachonproject.movementservice.domain.mudang.service.MudangDeleteService;
+import com.gachonproject.movementservice.domain.mudang.service.MudangGetService;
+import com.gachonproject.movementservice.domain.mudang.service.MudangSaveService;
+import com.gachonproject.movementservice.domain.mudang.service.MudangUpdateService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MudangUseCase {
+
+    private static final String TIME_FORMAT = "HH:mm";
+    private static final String RESPONSE_FORMAT = "%s분 무당이가 %s분 뒤 도착 예정입니다.";
+
+    private final MudangSaveService mudangSaveService;
+    private final MudangGetService mudangGetService;
+    private final MudangUpdateService mudangUpdateService;
+    private final MudangDeleteService mudangDeleteService;
+
+    public void createMudang(MudangSaveDto dto) {
+
+        mudangGetService.checkValidTime(dto.timeslot());
+
+        mudangSaveService.saveMudang(Mudang.from(dto));
+    }
+
+
+
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/usecase/MudangUseCase.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/mudang/usecase/MudangUseCase.java
@@ -56,6 +56,11 @@ public class MudangUseCase {
         mudangUpdateService.updateMudang(findMudang, dto.timeslot());
     }
 
+    @Transactional
+    public void deleteMudang(Long mudangId) {
+        Mudang findMudang = mudangGetService.getMudangByMudangId(mudangId);
+        mudangDeleteService.deleteMudang(findMudang);
+    }
 
 
     /*

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/global/common/entity/BaseEntity.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/global/common/entity/BaseEntity.java
@@ -1,0 +1,30 @@
+package com.gachonproject.movementservice.global.common.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@SuperBuilder
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createDate;
+
+    @LastModifiedDate
+    private LocalDateTime updateDate;
+}

--- a/Movement-Service/src/main/resources/application-dev.yml
+++ b/Movement-Service/src/main/resources/application-dev.yml
@@ -1,13 +1,25 @@
 server:
   port: 8083
 
-spring:
-  application:
-    name: movement-service
-
 eureka:
   client:
     register-with-eureka: true
     fetch-registry: true
     service-url: # Discovery-Service Docker Container Name
       defaultZone: http://${DISCOVERY_SERVICE}:8761/eureka
+
+spring:
+  application:
+    name: movement-service
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: update

--- a/Movement-Service/src/main/resources/application.yml
+++ b/Movement-Service/src/main/resources/application.yml
@@ -1,13 +1,25 @@
 server:
   port: 8083
 
-spring:
-  application:
-    name: movement-service
-
 eureka:
   client:
     register-with-eureka: true
     fetch-registry: true
     service-url:
       defaultZone: http://localhost:8761/eureka
+
+spring:
+  application:
+    name: movement-service
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: update

--- a/User-Service/src/main/java/com/gachonproject/userservice/domain/user/controller/UserController.java
+++ b/User-Service/src/main/java/com/gachonproject/userservice/domain/user/controller/UserController.java
@@ -20,10 +20,10 @@ public class UserController {
     private final UserUseCase userUseCase;
 
     @GetMapping("/user")
-    public ApiResponse<List<UserResponseDto>> getUserList(@RequestParam(defaultValue = "0", required = false) int pageNumber,
+    public ApiResponse<List<UserResponseDto>> getUserList(@RequestParam(defaultValue = "0", required = false) int pageNum,
                                                           @RequestParam(defaultValue = "5", required = false) int pageSize) {
 
-        List<UserResponseDto> response = userUseCase.findUserList(pageNumber, pageSize);
+        List<UserResponseDto> response = userUseCase.findUserList(pageNum, pageSize);
 
         return ApiResponse.response(OK, USER_LIST_SUCCESS.getMessage(), response);
     }

--- a/User-Service/src/main/java/com/gachonproject/userservice/domain/user/service/UserGetService.java
+++ b/User-Service/src/main/java/com/gachonproject/userservice/domain/user/service/UserGetService.java
@@ -29,8 +29,8 @@ public class UserGetService {
                 .orElseThrow(UserNotFoundException::new);
     }
 
-    public List<User> findUserList(int pageNumber, int pageSize) {
-        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+    public List<User> findUserList(int pageNum, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNum, pageSize);
         return userRepository.findAll(pageable).getContent();
     }
 

--- a/User-Service/src/main/java/com/gachonproject/userservice/domain/user/usecase/UserUseCase.java
+++ b/User-Service/src/main/java/com/gachonproject/userservice/domain/user/usecase/UserUseCase.java
@@ -19,8 +19,8 @@ public class UserUseCase {
     private final UserDeleteService userDeleteService;
 
     @Transactional(readOnly = true)
-    public List<UserResponseDto> findUserList(int pageNumber, int pageSize) {
-        return userGetService.findUserList(pageNumber, pageSize)
+    public List<UserResponseDto> findUserList(int pageNum, int pageSize) {
+        return userGetService.findUserList(pageNum, pageSize)
                 .stream()
                 .map(UserResponseDto::from)
                 .toList();


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #6
Close #6


## 🚀 작업 내용
> PR에서 작업한 내용을 설명
- [ ] 무당이 시간표 생성 API 구현
- [ ] 가까운 무당이 시간 조회 API 구현
- [ ] 무당이 시간표 목록 API 구현
- [ ] 무당이 시간표 수정 API 구현
- [ ] 무당이 시간표 삭제 API 구현


### 가까운 무당이 시간 조회 API 구현

무당이 출발지는 AI 공학관이고 반도체대학까지 오는데 5분정도 걸립니다.   
무당이 시간표는 AI 공학관에서 출발하는 걸 기준으로 되어있습니다.   
따라서 09:00 출발 무당이는 09:05에 반도체대학에 도착한다는 점을 고려해야합니다.

1. 요청이 들어오면 현재 시각을 측정합니다.
2. 현재 시각에서 5분을 뺀다.
3. 5분 뺀 시간에서 DB를 조회한다. (다음 SQL 참고)
```sql
SELECT *
FROM mudang
WHERE timeslot >= '09:47'
ORDER BY timeslot ASC
LIMIT 1;
```
```java
// JPA 메서드
    Optional<Mudang> findFirstByTimeslotGreaterThanOrderByTimeslotAsc(String timeslot);
```

4. 몇분 뒤 도착하는 지 계산하기 위해서 조회한 Mudang의 timeslot과 5분을 뺀 시각의 차를 구합니다.
5. 정해진 문자열에 맞게 반환합니다.

```json
// 10시 53분에 요청을 보낸 경우
{
    "code": 200,
    "message": "무당이 시간표를 반환합니다.",
    "data": "10:50분 무당이가 2분 뒤 도착 예정입니다."
}
```

### 무당이 시간표 목록 API 구현

페이지네이션을 사용해 구현했습니다
```bash
// RequestParam
pageNum (페이지 번호, 기본 값 0)
pageSize (페이지 사이즈, 기본 값 10)

```


## 📸 스크린샷


## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
