### PR TITLE
Feat/#8/로드뷰 기능 구현

### DIFF
--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/RoadViewController.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/RoadViewController.java
@@ -2,17 +2,17 @@ package com.gachonproject.movementservice.domain.roadview.controller;
 
 
 import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewSaveDto;
+import com.gachonproject.movementservice.domain.roadview.dto.response.RoadViewDetailDto;
 import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
 import com.gachonproject.movementservice.domain.roadview.repository.RoadViewRepository;
 import com.gachonproject.movementservice.domain.roadview.usecase.RoadViewUseCase;
 import com.gachonproject.movementservice.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.gachonproject.movementservice.domain.roadview.controller.enums.SuccessMessage.ROAD_VIEW_CREATE_SUCCESS;
+import static com.gachonproject.movementservice.domain.roadview.controller.enums.SuccessMessage.ROAD_VIEW_DETAIL_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,5 +27,14 @@ public class RoadViewController {
 
         return ApiResponse.response(HttpStatus.OK, ROAD_VIEW_CREATE_SUCCESS.getMessage());
     }
+
+    @GetMapping("/member/road_view/{end_point}")
+    public ApiResponse<RoadViewDetailDto> getRoadView(@PathVariable(name = "end_point") String endPoint) {
+
+        RoadViewDetailDto response = roadViewUseCase.getRoadViewDetail(endPoint);
+
+        return ApiResponse.response(HttpStatus.OK, ROAD_VIEW_DETAIL_SUCCESS.getMessage(), response);
+    }
+
 
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/RoadViewController.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/RoadViewController.java
@@ -30,15 +30,15 @@ public class RoadViewController {
         return ApiResponse.response(HttpStatus.OK, ROAD_VIEW_CREATE_SUCCESS.getMessage());
     }
 
-    @GetMapping("/member/road_view/{end_point}")
-    public ApiResponse<RoadViewDetailDto> getRoadView(@PathVariable(name = "end_point") String endPoint) {
+    @GetMapping("/member/road_view/{endPoint}")
+    public ApiResponse<RoadViewDetailDto> getRoadView(@PathVariable(name = "endPoint") String endPoint) {
 
         RoadViewDetailDto response = roadViewUseCase.getRoadViewDetail(endPoint);
 
         return ApiResponse.response(HttpStatus.OK, ROAD_VIEW_DETAIL_SUCCESS.getMessage(), response);
     }
 
-    @GetMapping("/member/road_view")
+    @GetMapping("/member/roadView")
     public ApiResponse<List<RoadViewDetailDto>> getRoadViews(
             @RequestParam(defaultValue = "0", required = false) int pageNum,
             @RequestParam(defaultValue = "10", required = false) int pageSize
@@ -57,5 +57,12 @@ public class RoadViewController {
         return ApiResponse.response(HttpStatus.OK, ROAD_VIEW_UPDATE_SUCCESS.getMessage());
     }
 
+    @DeleteMapping("/admin/road_view/{roadViewId}")
+    public ApiResponse<Void> deleteRoadView(@PathVariable(name = "roadViewId") Long roadViewId) {
+
+        roadViewUseCase.deleteRoadView(roadViewId);
+
+        return ApiResponse.response(HttpStatus.OK, ROAD_VIEW_DELETE_SUCCESS.getMessage());
+    }
 
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/RoadViewController.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/RoadViewController.java
@@ -1,0 +1,31 @@
+package com.gachonproject.movementservice.domain.roadview.controller;
+
+
+import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewSaveDto;
+import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
+import com.gachonproject.movementservice.domain.roadview.repository.RoadViewRepository;
+import com.gachonproject.movementservice.domain.roadview.usecase.RoadViewUseCase;
+import com.gachonproject.movementservice.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.gachonproject.movementservice.domain.roadview.controller.enums.SuccessMessage.ROAD_VIEW_CREATE_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+public class RoadViewController {
+
+    private final RoadViewUseCase roadViewUseCase;
+
+    @PostMapping("/admin/road_view")
+    public ApiResponse<Void> createRoadView(@RequestBody RoadViewSaveDto dto) {
+
+        roadViewUseCase.saveRoadView(dto);
+
+        return ApiResponse.response(HttpStatus.OK, ROAD_VIEW_CREATE_SUCCESS.getMessage());
+    }
+
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/RoadViewController.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/RoadViewController.java
@@ -9,6 +9,7 @@ import com.gachonproject.movementservice.domain.roadview.repository.RoadViewRepo
 import com.gachonproject.movementservice.domain.roadview.usecase.RoadViewUseCase;
 import com.gachonproject.movementservice.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -38,7 +39,7 @@ public class RoadViewController {
         return ApiResponse.response(HttpStatus.OK, ROAD_VIEW_DETAIL_SUCCESS.getMessage(), response);
     }
 
-    @GetMapping("/member/roadView")
+    @GetMapping("/member/road_view")
     public ApiResponse<List<RoadViewDetailDto>> getRoadViews(
             @RequestParam(defaultValue = "0", required = false) int pageNum,
             @RequestParam(defaultValue = "10", required = false) int pageSize

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/RoadViewController.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/RoadViewController.java
@@ -11,8 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import static com.gachonproject.movementservice.domain.roadview.controller.enums.SuccessMessage.ROAD_VIEW_CREATE_SUCCESS;
-import static com.gachonproject.movementservice.domain.roadview.controller.enums.SuccessMessage.ROAD_VIEW_DETAIL_SUCCESS;
+import java.util.List;
+
+import static com.gachonproject.movementservice.domain.roadview.controller.enums.SuccessMessage.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,6 +35,17 @@ public class RoadViewController {
         RoadViewDetailDto response = roadViewUseCase.getRoadViewDetail(endPoint);
 
         return ApiResponse.response(HttpStatus.OK, ROAD_VIEW_DETAIL_SUCCESS.getMessage(), response);
+    }
+
+    @GetMapping("/member/road_view")
+    public ApiResponse<List<RoadViewDetailDto>> getRoadViews(
+            @RequestParam(defaultValue = "0", required = false) int pageNum,
+            @RequestParam(defaultValue = "10", required = false) int pageSize
+    ) {
+
+        List<RoadViewDetailDto> response = roadViewUseCase.getRoadViewList(pageNum, pageSize);
+
+        return ApiResponse.response(HttpStatus.OK, ROAD_VIEW_LIST_SUCCESS.getMessage(), response);
     }
 
 

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/RoadViewController.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/RoadViewController.java
@@ -2,6 +2,7 @@ package com.gachonproject.movementservice.domain.roadview.controller;
 
 
 import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewSaveDto;
+import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewUpdateDto;
 import com.gachonproject.movementservice.domain.roadview.dto.response.RoadViewDetailDto;
 import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
 import com.gachonproject.movementservice.domain.roadview.repository.RoadViewRepository;
@@ -46,6 +47,14 @@ public class RoadViewController {
         List<RoadViewDetailDto> response = roadViewUseCase.getRoadViewList(pageNum, pageSize);
 
         return ApiResponse.response(HttpStatus.OK, ROAD_VIEW_LIST_SUCCESS.getMessage(), response);
+    }
+
+    @PatchMapping("/admin/road_view")
+    public ApiResponse<Void> updateRoadView(@RequestBody RoadViewUpdateDto dto) {
+
+        roadViewUseCase.updateRoadView(dto);
+
+        return ApiResponse.response(HttpStatus.OK, ROAD_VIEW_UPDATE_SUCCESS.getMessage());
     }
 
 

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/enums/SuccessMessage.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/enums/SuccessMessage.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessMessage {
 
+    ROAD_VIEW_DETAIL_SUCCESS("로드뷰 정보를 조회했습니다."),
     ROAD_VIEW_CREATE_SUCCESS("로드뷰 정보를 생성했습니다.");
 
     private final String message;

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/enums/SuccessMessage.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/enums/SuccessMessage.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessMessage {
 
+    ROAD_VIEW_LIST_SUCCESS("로드뷰 정보 목록을 반환합니다."),
     ROAD_VIEW_DETAIL_SUCCESS("로드뷰 정보를 조회했습니다."),
     ROAD_VIEW_CREATE_SUCCESS("로드뷰 정보를 생성했습니다.");
 

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/enums/SuccessMessage.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/enums/SuccessMessage.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessMessage {
 
+    ROAD_VIEW_DELETE_SUCCESS("로드뷰 정보를 삭제합니다."),
     ROAD_VIEW_UPDATE_SUCCESS("로드뷰 정보를 수정합니다."),
     ROAD_VIEW_LIST_SUCCESS("로드뷰 정보 목록을 반환합니다."),
     ROAD_VIEW_DETAIL_SUCCESS("로드뷰 정보를 조회했습니다."),

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/enums/SuccessMessage.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/enums/SuccessMessage.java
@@ -1,0 +1,14 @@
+package com.gachonproject.movementservice.domain.roadview.controller.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessMessage {
+
+    ROAD_VIEW_CREATE_SUCCESS("로드뷰 정보를 생성했습니다.");
+
+    private final String message;
+
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/enums/SuccessMessage.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/controller/enums/SuccessMessage.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessMessage {
 
+    ROAD_VIEW_UPDATE_SUCCESS("로드뷰 정보를 수정합니다."),
     ROAD_VIEW_LIST_SUCCESS("로드뷰 정보 목록을 반환합니다."),
     ROAD_VIEW_DETAIL_SUCCESS("로드뷰 정보를 조회했습니다."),
     ROAD_VIEW_CREATE_SUCCESS("로드뷰 정보를 생성했습니다.");

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/dto/request/RoadViewSaveDto.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/dto/request/RoadViewSaveDto.java
@@ -1,0 +1,7 @@
+package com.gachonproject.movementservice.domain.roadview.dto.request;
+
+public record RoadViewSaveDto(
+        String endPoint,
+        String url
+) {
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/dto/request/RoadViewUpdateDto.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/dto/request/RoadViewUpdateDto.java
@@ -1,0 +1,8 @@
+package com.gachonproject.movementservice.domain.roadview.dto.request;
+
+public record RoadViewUpdateDto(
+        Long roadViewId,
+        String endPoint,
+        String url
+) {
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/dto/response/RoadViewDetailDto.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/dto/response/RoadViewDetailDto.java
@@ -1,0 +1,19 @@
+package com.gachonproject.movementservice.domain.roadview.dto.response;
+
+import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
+import lombok.Builder;
+
+@Builder
+public record RoadViewDetailDto(
+        Long roadViewId,
+        String endPoint,
+        String url
+) {
+    public static RoadViewDetailDto from(RoadView roadView) {
+        return RoadViewDetailDto.builder()
+                .roadViewId(roadView.getId())
+                .endPoint(roadView.getEndPoint())
+                .url(roadView.getUrl())
+                .build();
+    }
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/entity/RoadView.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/entity/RoadView.java
@@ -1,0 +1,33 @@
+package com.gachonproject.movementservice.domain.roadview.entity;
+
+import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewSaveDto;
+import com.gachonproject.movementservice.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@Table(name = "road_view")
+@SuperBuilder
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class RoadView extends BaseEntity {
+
+    @Column(nullable = false, length = 50)
+    String endPoint;
+
+    @Column(nullable = false, length = 512)
+    String url;
+
+    public static RoadView from(RoadViewSaveDto dto) {
+        return RoadView.builder()
+                .endPoint(dto.endPoint())
+                .url(dto.url())
+                .build();
+    }
+
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/entity/RoadView.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/entity/RoadView.java
@@ -1,6 +1,7 @@
 package com.gachonproject.movementservice.domain.roadview.entity;
 
 import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewSaveDto;
+import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewUpdateDto;
 import com.gachonproject.movementservice.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -28,6 +29,11 @@ public class RoadView extends BaseEntity {
                 .endPoint(dto.endPoint())
                 .url(dto.url())
                 .build();
+    }
+
+    public void updateRoadView(RoadViewUpdateDto dto) {
+        this.endPoint = dto.endPoint();
+        this.url = dto.url();
     }
 
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/exception/DuplicatedRoadViewException.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/exception/DuplicatedRoadViewException.java
@@ -1,0 +1,12 @@
+package com.gachonproject.movementservice.domain.roadview.exception;
+
+import com.gachonproject.movementservice.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import static com.gachonproject.movementservice.domain.roadview.exception.enums.ErrorMessage.DUPLICATED_ROAD_VIEW;
+
+public class DuplicatedRoadViewException extends BaseException {
+    public DuplicatedRoadViewException() {
+        super(HttpStatus.BAD_REQUEST, DUPLICATED_ROAD_VIEW.getMessage());
+    }
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/exception/RoadViewNotFoundException.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/exception/RoadViewNotFoundException.java
@@ -1,0 +1,12 @@
+package com.gachonproject.movementservice.domain.roadview.exception;
+
+import com.gachonproject.movementservice.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import static com.gachonproject.movementservice.domain.roadview.exception.enums.ErrorMessage.ROAD_VIEW_NOT_FOUND;
+
+public class RoadViewNotFoundException extends BaseException {
+    public RoadViewNotFoundException() {
+        super(HttpStatus.BAD_REQUEST, ROAD_VIEW_NOT_FOUND.getMessage());
+    }
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/exception/enums/ErrorMessage.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/exception/enums/ErrorMessage.java
@@ -1,0 +1,14 @@
+package com.gachonproject.movementservice.domain.roadview.exception.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    DUPLICATED_ROAD_VIEW("중복되는 로드뷰 도착지입니다."),
+    ROAD_VIEW_NOT_FOUND("해당 로드뷰를 찾을 수 없습니다.");
+
+    private final String message;
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/repository/RoadViewRepository.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/repository/RoadViewRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface RoadViewRepository extends JpaRepository<RoadView, Long> {
 
     Optional<RoadView> findRoadViewByEndPoint(String entPoint);
+
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/repository/RoadViewRepository.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/repository/RoadViewRepository.java
@@ -1,12 +1,15 @@
 package com.gachonproject.movementservice.domain.roadview.repository;
 
 import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RoadViewRepository extends JpaRepository<RoadView, Long> {
 
     Optional<RoadView> findRoadViewByEndPoint(String entPoint);
 
+    List<RoadView> findRoadViewAll(Pageable pageable);
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/repository/RoadViewRepository.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/repository/RoadViewRepository.java
@@ -1,0 +1,11 @@
+package com.gachonproject.movementservice.domain.roadview.repository;
+
+import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoadViewRepository extends JpaRepository<RoadView, Long> {
+
+    Optional<RoadView> findRoadViewByEndPoint(String entPoint);
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/repository/RoadViewRepository.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/repository/RoadViewRepository.java
@@ -1,6 +1,7 @@
 package com.gachonproject.movementservice.domain.roadview.repository;
 
 import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,5 +12,6 @@ public interface RoadViewRepository extends JpaRepository<RoadView, Long> {
 
     Optional<RoadView> findRoadViewByEndPoint(String entPoint);
 
-    List<RoadView> findRoadViewAll(Pageable pageable);
+    Page<RoadView> findAll(Pageable pageable);
+
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewDeleteService.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewDeleteService.java
@@ -1,0 +1,19 @@
+package com.gachonproject.movementservice.domain.roadview.service;
+
+import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
+import com.gachonproject.movementservice.domain.roadview.repository.RoadViewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RoadViewDeleteService {
+
+    private final RoadViewRepository roadViewRepository;
+
+    @Transactional
+    public void delete(RoadView roadView) {
+        roadViewRepository.delete(roadView);
+    }
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewGetService.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewGetService.java
@@ -1,12 +1,11 @@
 package com.gachonproject.movementservice.domain.roadview.service;
 
-import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewSaveDto;
-import com.gachonproject.movementservice.domain.roadview.dto.response.RoadViewDetailDto;
 import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
 import com.gachonproject.movementservice.domain.roadview.exception.DuplicatedRoadViewException;
 import com.gachonproject.movementservice.domain.roadview.exception.RoadViewNotFoundException;
 import com.gachonproject.movementservice.domain.roadview.repository.RoadViewRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -20,7 +19,10 @@ public class RoadViewGetService {
 
     public void checkDuplicatedRoadView(String endPoint) {
         roadViewRepository.findRoadViewByEndPoint(endPoint)
-                .orElseThrow(DuplicatedRoadViewException::new);
+                .ifPresent(roadView -> {
+                    throw new DuplicatedRoadViewException();
+                });
+
     }
 
     public RoadView findRoadView(Long roadViewId) {
@@ -33,8 +35,8 @@ public class RoadViewGetService {
                 .orElseThrow(RoadViewNotFoundException::new);
     }
 
-    public List<RoadView> findRoadViewList(Pageable pageable) {
-        return roadViewRepository.findRoadViewAll(pageable);
+    public Page<RoadView> findRoadViewList(Pageable pageable) {
+        return roadViewRepository.findAll(pageable);
     }
 
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewGetService.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewGetService.java
@@ -1,7 +1,10 @@
 package com.gachonproject.movementservice.domain.roadview.service;
 
 import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewSaveDto;
+import com.gachonproject.movementservice.domain.roadview.dto.response.RoadViewDetailDto;
+import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
 import com.gachonproject.movementservice.domain.roadview.exception.DuplicatedRoadViewException;
+import com.gachonproject.movementservice.domain.roadview.exception.RoadViewNotFoundException;
 import com.gachonproject.movementservice.domain.roadview.repository.RoadViewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +18,11 @@ public class RoadViewGetService {
     public void checkDuplicatedRoadView(String endPoint) {
         roadViewRepository.findRoadViewByEndPoint(endPoint)
                 .orElseThrow(DuplicatedRoadViewException::new);
+    }
+
+    public RoadView findRoadView(String endPoint) {
+        return roadViewRepository.findRoadViewByEndPoint(endPoint)
+                .orElseThrow(RoadViewNotFoundException::new);
     }
 
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewGetService.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewGetService.java
@@ -7,7 +7,10 @@ import com.gachonproject.movementservice.domain.roadview.exception.DuplicatedRoa
 import com.gachonproject.movementservice.domain.roadview.exception.RoadViewNotFoundException;
 import com.gachonproject.movementservice.domain.roadview.repository.RoadViewRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +26,10 @@ public class RoadViewGetService {
     public RoadView findRoadView(String endPoint) {
         return roadViewRepository.findRoadViewByEndPoint(endPoint)
                 .orElseThrow(RoadViewNotFoundException::new);
+    }
+
+    public List<RoadView> findRoadViewList(Pageable pageable) {
+        return roadViewRepository.findRoadViewAll(pageable);
     }
 
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewGetService.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewGetService.java
@@ -23,6 +23,11 @@ public class RoadViewGetService {
                 .orElseThrow(DuplicatedRoadViewException::new);
     }
 
+    public RoadView findRoadView(Long roadViewId) {
+        return roadViewRepository.findById(roadViewId)
+                .orElseThrow(RoadViewNotFoundException::new);
+    }
+
     public RoadView findRoadView(String endPoint) {
         return roadViewRepository.findRoadViewByEndPoint(endPoint)
                 .orElseThrow(RoadViewNotFoundException::new);

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewGetService.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewGetService.java
@@ -1,0 +1,20 @@
+package com.gachonproject.movementservice.domain.roadview.service;
+
+import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewSaveDto;
+import com.gachonproject.movementservice.domain.roadview.exception.DuplicatedRoadViewException;
+import com.gachonproject.movementservice.domain.roadview.repository.RoadViewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoadViewGetService {
+
+    private final RoadViewRepository roadViewRepository;
+
+    public void checkDuplicatedRoadView(String endPoint) {
+        roadViewRepository.findRoadViewByEndPoint(endPoint)
+                .orElseThrow(DuplicatedRoadViewException::new);
+    }
+
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewSaveService.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewSaveService.java
@@ -1,0 +1,18 @@
+package com.gachonproject.movementservice.domain.roadview.service;
+
+import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewSaveDto;
+import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
+import com.gachonproject.movementservice.domain.roadview.repository.RoadViewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoadViewSaveService {
+
+    private final RoadViewRepository roadViewRepository;
+
+    public void saveRoadView(RoadViewSaveDto dto) {
+        roadViewRepository.save(RoadView.from(dto));
+    }
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewUpdateService.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/service/RoadViewUpdateService.java
@@ -1,0 +1,21 @@
+package com.gachonproject.movementservice.domain.roadview.service;
+
+import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewUpdateDto;
+import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
+import com.gachonproject.movementservice.domain.roadview.repository.RoadViewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RoadViewUpdateService {
+
+    private final RoadViewRepository roadViewRepository;
+
+    @Transactional
+    public void updateRoadView(RoadView roadView, RoadViewUpdateDto dto){
+        roadView.updateRoadView(dto);
+    }
+
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/usecase/RoadViewUseCase.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/usecase/RoadViewUseCase.java
@@ -1,14 +1,17 @@
 package com.gachonproject.movementservice.domain.roadview.usecase;
 
 import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewSaveDto;
+import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewUpdateDto;
 import com.gachonproject.movementservice.domain.roadview.dto.response.RoadViewDetailDto;
 import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
 import com.gachonproject.movementservice.domain.roadview.service.RoadViewGetService;
 import com.gachonproject.movementservice.domain.roadview.service.RoadViewSaveService;
+import com.gachonproject.movementservice.domain.roadview.service.RoadViewUpdateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -18,6 +21,7 @@ public class RoadViewUseCase {
 
     private final RoadViewSaveService roadViewSaveService;
     private final RoadViewGetService roadViewGetService;
+    private final RoadViewUpdateService roadViewUpdateService;
 
     public void saveRoadView(RoadViewSaveDto dto) {
 
@@ -41,6 +45,14 @@ public class RoadViewUseCase {
                 .stream()
                 .map(RoadViewDetailDto::from)
                 .toList();
+    }
+
+    @Transactional
+    public void updateRoadView(RoadViewUpdateDto dto) {
+
+        RoadView roadView = roadViewGetService.findRoadView(dto.roadViewId());
+
+        roadViewUpdateService.updateRoadView(roadView, dto);
     }
 
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/usecase/RoadViewUseCase.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/usecase/RoadViewUseCase.java
@@ -1,0 +1,22 @@
+package com.gachonproject.movementservice.domain.roadview.usecase;
+
+import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewSaveDto;
+import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
+import com.gachonproject.movementservice.domain.roadview.service.RoadViewGetService;
+import com.gachonproject.movementservice.domain.roadview.service.RoadViewSaveService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoadViewUseCase {
+
+    private final RoadViewSaveService roadViewSaveService;
+    private final RoadViewGetService roadViewGetService;
+
+    public void saveRoadView(RoadViewSaveDto dto) {
+        roadViewGetService.checkDuplicatedRoadView(dto.endPoint());
+        roadViewSaveService.saveRoadView(dto);
+    }
+
+}

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/usecase/RoadViewUseCase.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/usecase/RoadViewUseCase.java
@@ -4,6 +4,7 @@ import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewSav
 import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewUpdateDto;
 import com.gachonproject.movementservice.domain.roadview.dto.response.RoadViewDetailDto;
 import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
+import com.gachonproject.movementservice.domain.roadview.service.RoadViewDeleteService;
 import com.gachonproject.movementservice.domain.roadview.service.RoadViewGetService;
 import com.gachonproject.movementservice.domain.roadview.service.RoadViewSaveService;
 import com.gachonproject.movementservice.domain.roadview.service.RoadViewUpdateService;
@@ -22,6 +23,7 @@ public class RoadViewUseCase {
     private final RoadViewSaveService roadViewSaveService;
     private final RoadViewGetService roadViewGetService;
     private final RoadViewUpdateService roadViewUpdateService;
+    private final RoadViewDeleteService roadViewDeleteService;
 
     public void saveRoadView(RoadViewSaveDto dto) {
 
@@ -53,6 +55,14 @@ public class RoadViewUseCase {
         RoadView roadView = roadViewGetService.findRoadView(dto.roadViewId());
 
         roadViewUpdateService.updateRoadView(roadView, dto);
+    }
+
+    @Transactional
+    public void deleteRoadView(Long roadViewId) {
+
+        RoadView findRoadView = roadViewGetService.findRoadView(roadViewId);
+
+        roadViewDeleteService.delete(findRoadView);
     }
 
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/usecase/RoadViewUseCase.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/usecase/RoadViewUseCase.java
@@ -6,7 +6,11 @@ import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
 import com.gachonproject.movementservice.domain.roadview.service.RoadViewGetService;
 import com.gachonproject.movementservice.domain.roadview.service.RoadViewSaveService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +31,16 @@ public class RoadViewUseCase {
         RoadView findRoadView = roadViewGetService.findRoadView(endPoint);
 
         return RoadViewDetailDto.from(findRoadView);
+    }
+
+    public List<RoadViewDetailDto> getRoadViewList(int pageNum, int pageSize) {
+
+        Pageable pageable = PageRequest.of(pageNum, pageSize);
+
+        return roadViewGetService.findRoadViewList(pageable)
+                .stream()
+                .map(RoadViewDetailDto::from)
+                .toList();
     }
 
 }

--- a/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/usecase/RoadViewUseCase.java
+++ b/Movement-Service/src/main/java/com/gachonproject/movementservice/domain/roadview/usecase/RoadViewUseCase.java
@@ -1,6 +1,7 @@
 package com.gachonproject.movementservice.domain.roadview.usecase;
 
 import com.gachonproject.movementservice.domain.roadview.dto.request.RoadViewSaveDto;
+import com.gachonproject.movementservice.domain.roadview.dto.response.RoadViewDetailDto;
 import com.gachonproject.movementservice.domain.roadview.entity.RoadView;
 import com.gachonproject.movementservice.domain.roadview.service.RoadViewGetService;
 import com.gachonproject.movementservice.domain.roadview.service.RoadViewSaveService;
@@ -15,8 +16,17 @@ public class RoadViewUseCase {
     private final RoadViewGetService roadViewGetService;
 
     public void saveRoadView(RoadViewSaveDto dto) {
+
         roadViewGetService.checkDuplicatedRoadView(dto.endPoint());
         roadViewSaveService.saveRoadView(dto);
+
+    }
+
+    public RoadViewDetailDto getRoadViewDetail(String endPoint) {
+
+        RoadView findRoadView = roadViewGetService.findRoadView(endPoint);
+
+        return RoadViewDetailDto.from(findRoadView);
     }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #8 
Close #8 


## 🚀 작업 내용
> PR에서 작업한 내용을 설명

- [ ] 로드뷰 정보 생성 API 구현
- [ ] 로드뷰 정보 조회 API 구현
- [ ] 로드뷰 정보 목록 조회 API 구현
- [ ] 로드뷰 정보 수정 API 구현
- [ ] 로드뷰 정보 삭제 API 구현


### 로드뷰 URL 구하는 방법

1. 네이버지도 접속
2. 네이버 지도에서 출발지(가천대역 1번출구), 도착지 설정 후 길찾기
3. 거리뷰 클릭
4. 거리뷰 전체 모드로 확대 후 해당 URL 복사

### 로드뷰 정보 중 발생한 이슈

- 학군단 건물이 2023년에 없어져 URL 링크 'X' 처리했습니다.   
- 기숙사는 제1-3기숙사까지 존재하기 때문에 제3기숙사, 제2기숙사, 제1기숙사로 나누어 거리뷰 URL 링크를 저장했습니다.   
- 프리덤 광장. 스타덤 광장은 지하에 위치해있어 네이버지도에 보이지 않아서 테이블에 저장하지 않았습니다.   


### 로드뷰 정보 목록 페이지네이션 

사용자, 무당이 정보와 동일하게 로드뷰 또한 페이지네이션 처리 했습니다.


## 📸 스크린샷


## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
