### PR TITLE
Feat: 추가 api 구현

### DIFF
--- a/ApiGateway-Service/src/main/java/com/gachonproject/apigatewayservice/auth/filter/AuthenticationFilter.java
+++ b/ApiGateway-Service/src/main/java/com/gachonproject/apigatewayservice/auth/filter/AuthenticationFilter.java
@@ -28,7 +28,7 @@ public class AuthenticationFilter extends AbstractGatewayFilterFactory<Authentic
 
     // 인증 예외 (모든 사용자 접근 허용)
     private static final List<String> whiteList = List.of(
-            "/signin", "/signup", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**"
+            "/normal/**", "/signin", "/signup", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**"
     );
 
     // USER 접근 허용 경로 (ADMIN도 허용)

--- a/User-Service/src/main/java/com/gachonproject/userservice/domain/user/controller/UserController.java
+++ b/User-Service/src/main/java/com/gachonproject/userservice/domain/user/controller/UserController.java
@@ -13,13 +13,12 @@ import static com.gachonproject.userservice.domain.user.controller.enums.Respons
 import static org.springframework.http.HttpStatus.OK;
 
 @RestController
-@RequestMapping("/admin")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserUseCase userUseCase;
 
-    @GetMapping("/user")
+    @GetMapping("/admin/user")
     public ApiResponse<List<UserResponseDto>> getUserList(@RequestParam(defaultValue = "0", required = false) int pageNum,
                                                           @RequestParam(defaultValue = "5", required = false) int pageSize) {
 
@@ -28,7 +27,7 @@ public class UserController {
         return ApiResponse.response(OK, USER_LIST_SUCCESS.getMessage(), response);
     }
 
-    @PatchMapping("/user")
+    @PatchMapping("/admin/user")
     public ApiResponse<Void> updateUser(@RequestBody UserUpdateDto dto) {
 
         userUseCase.updateUser(dto);
@@ -36,7 +35,7 @@ public class UserController {
         return ApiResponse.response(OK, USER_UPDATE_SUCCESS.getMessage());
     }
 
-    @DeleteMapping("/user/{userId}")
+    @DeleteMapping("/admin/user/{userId}")
     public ApiResponse<Void> deleteUser(@PathVariable Long userId) {
 
         userUseCase.deleteUser(userId);
@@ -44,4 +43,13 @@ public class UserController {
         return ApiResponse.response(OK, USER_DELETE_SUCCESS.getMessage());
     }
 
+    @GetMapping("/normal/login_id/{loginId}")
+    public ApiResponse<Boolean> checkLoginId(@PathVariable String loginId) {
+
+        if (userUseCase.checkLoginId(loginId)) {
+            return ApiResponse.response(OK, LOGIN_ID_VALIDATE.getMessage(), true);
+        }
+
+        return ApiResponse.response(OK, LOGIN_ID_INVALIDATE.getMessage(), false);
+    }
 }

--- a/User-Service/src/main/java/com/gachonproject/userservice/domain/user/controller/UserController.java
+++ b/User-Service/src/main/java/com/gachonproject/userservice/domain/user/controller/UserController.java
@@ -52,4 +52,14 @@ public class UserController {
 
         return ApiResponse.response(OK, LOGIN_ID_INVALIDATE.getMessage(), false);
     }
+
+    @GetMapping("/normal/student_id/{studentId}")
+    public ApiResponse<Boolean> checkStudentId(@PathVariable String studentId) {
+
+        if (userUseCase.checkStudentId(studentId)) {
+            return ApiResponse.response(OK, STUDENT_ID_VALIDATE.getMessage(), true);
+        }
+
+        return ApiResponse.response(OK, STUDENT_ID_INVALIDATE.getMessage(), false);
+    }
 }

--- a/User-Service/src/main/java/com/gachonproject/userservice/domain/user/controller/enums/ResponseMessage.java
+++ b/User-Service/src/main/java/com/gachonproject/userservice/domain/user/controller/enums/ResponseMessage.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 public enum ResponseMessage {
 
     // UserController
+    STUDENT_ID_VALIDATE("사용 가능한 학번입니다."),
+    STUDENT_ID_INVALIDATE("이미 사용중인 학번입니다."),
     LOGIN_ID_VALIDATE("사용 가능한 아이디입니다."),
     LOGIN_ID_INVALIDATE("이미 사용중인 아이디입니다."),
     USER_LIST_SUCCESS("사용자 목록을 반환합니다. "),

--- a/User-Service/src/main/java/com/gachonproject/userservice/domain/user/controller/enums/ResponseMessage.java
+++ b/User-Service/src/main/java/com/gachonproject/userservice/domain/user/controller/enums/ResponseMessage.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 public enum ResponseMessage {
 
     // UserController
+    LOGIN_ID_VALIDATE("사용 가능한 아이디입니다."),
+    LOGIN_ID_INVALIDATE("이미 사용중인 아이디입니다."),
     USER_LIST_SUCCESS("사용자 목록을 반환합니다. "),
     USER_UPDATE_SUCCESS("사용자 정보를 수정했습니다."),
     USER_DELETE_SUCCESS("사용자를 삭제(회원탈퇴)했습니다."),

--- a/User-Service/src/main/java/com/gachonproject/userservice/domain/user/dto/response/LoginResponseDto.java
+++ b/User-Service/src/main/java/com/gachonproject/userservice/domain/user/dto/response/LoginResponseDto.java
@@ -1,0 +1,14 @@
+package com.gachonproject.userservice.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record LoginResponseDto(
+        String role
+) {
+    public static LoginResponseDto from(String role) {
+        return LoginResponseDto.builder()
+                .role(role)
+                .build();
+    }
+}

--- a/User-Service/src/main/java/com/gachonproject/userservice/domain/user/usecase/UserUseCase.java
+++ b/User-Service/src/main/java/com/gachonproject/userservice/domain/user/usecase/UserUseCase.java
@@ -47,4 +47,9 @@ public class UserUseCase {
         return !userGetService.validateLoginId(loginId);
     }
 
+    public boolean checkStudentId(String studentId){
+        // 이미 존재하는 경우
+        return !userGetService.validateStudentId(studentId);
+    }
+
 }

--- a/User-Service/src/main/java/com/gachonproject/userservice/domain/user/usecase/UserUseCase.java
+++ b/User-Service/src/main/java/com/gachonproject/userservice/domain/user/usecase/UserUseCase.java
@@ -42,4 +42,9 @@ public class UserUseCase {
         userDeleteService.delete(findUser);
     }
 
+    public boolean checkLoginId(String loginId){
+        // 이미 존재하는 경우
+        return !userGetService.validateLoginId(loginId);
+    }
+
 }

--- a/User-Service/src/main/java/com/gachonproject/userservice/global/auth/filter/LoginFilter.java
+++ b/User-Service/src/main/java/com/gachonproject/userservice/global/auth/filter/LoginFilter.java
@@ -1,6 +1,7 @@
 package com.gachonproject.userservice.global.auth.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gachonproject.userservice.domain.user.dto.response.LoginResponseDto;
 import com.gachonproject.userservice.global.auth.dto.LoginRequest;
 import com.gachonproject.userservice.global.auth.jwt.CustomUserDetails;
 import com.gachonproject.userservice.global.auth.util.JwtProvider;
@@ -28,6 +29,10 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final AuthenticationManager authenticationManager;
     private final JwtProvider jwtProvider;
+
+    private static final String LOGIN_SUCCESS_MESSAGE = "로그인에 성공했습니다.";
+    private static final String LOGIN_FAIL_MESSAGE = "로그인에 실패했습니다.";
+
 
 
     public LoginFilter(AuthenticationManager authenticationManager, JwtProvider jwtProvider) {
@@ -65,8 +70,10 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         response.setCharacterEncoding("UTF-8");
         response.setStatus(HttpStatus.OK.value());
 
+        LoginResponseDto data = LoginResponseDto.from(userRole);
+
         response.getWriter().write(new ObjectMapper().writeValueAsString(
-                ApiResponse.response(HttpStatus.OK, "로그인 성공!"))
+                ApiResponse.response(HttpStatus.OK, LOGIN_SUCCESS_MESSAGE, data))
         );
     }
 
@@ -79,7 +86,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         response.setContentType("application/json"); // 응답을 JSON으로
 
         response.getWriter().write(new ObjectMapper().writeValueAsString(
-                ApiResponse.response(HttpStatus.UNAUTHORIZED, "로그인 실패")
+                ApiResponse.response(HttpStatus.UNAUTHORIZED, LOGIN_FAIL_MESSAGE)
         ));
     }
 
@@ -87,6 +94,6 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
         GrantedAuthority auth = iterator.next();
-        return  auth.getAuthority();
+        return auth.getAuthority();
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #11 
Close #11 


## 🚀 작업 내용
> PR에서 작업한 내용을 설명
- [ ] 아이디 중복 검사 API 구현
- [ ] 학번 중복 검사 API 구현
- [ ] 로그인 시 MEMBER인지 ADMIN인지 반환


### 아이디 중복 검사 API 구현

사용 가능한 ID인 경우
```json
{
    "code": 200,
    "message": "사용 가능한 아이디입니다.",
    "data": true
}
```
이미 사용중인 ID인 경우
```json
{
    "code": 200,
    "message": "이미 사용중인 아이디입니다.",
    "data": false
}
```

<hr>

### 학번 중복 검사 API 구현
사용 가능한 학번인 경우
```json
{
    "code": 200,
    "message": "사용 가능한 학번입니다.",
    "data": true
}
```
이미 사용중인 학번인 경우
```json
{
    "code": 200,
    "message": "이미 사용중인 학번입니다.",
    "data": false
}
```

<hr>

### 로그인 시 역할 반환

USER인 경우
```json
{
    "code": 200,
    "message": "로그인에 성공했습니다.",
    "data": {
        "role": "USER"
    }
}
```

ADMIN인 경우
```json
{
    "code": 200,
    "message": "로그인에 성공했습니다.",
    "data": {
        "role": "ADMIN"
    }
}
```


## 📸 스크린샷


## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

FE 담당자 분과 이야기를 나눠 중복 검사의 경우   
사용 가능하면 true, 이미 가입된 ID, 학번이면 false를 반환하도록 약속했습니다.
